### PR TITLE
ci: add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+                php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         steps:
             -
                 name: Checkout code


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the CI test matrix to ensure compatibility with the upcoming PHP version

## Test plan
- [ ] CI passes on all PHP versions including 8.5