### PR TITLE
Add /tests to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 /phpcs.xml.dist export-ignore
 /phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
+/tests export-ignore


### PR DESCRIPTION
Exclude tests directory from distribution archives to reduce package size.