### PR TITLE
Upgrade shipmonk/dead-code-detector to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^9.6.22",
         "shipmonk/coding-standard": "^0.2.0",
         "shipmonk/composer-dependency-analyser": "^1.8.1",
-        "shipmonk/dead-code-detector": "^0.9.0",
+        "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "^2.1.1"
     },
     "suggest": {


### PR DESCRIPTION
## Summary
- Upgrade `shipmonk/dead-code-detector` from `^0.9.0` to `^1.0`

Co-Authored-By: Claude Code