### PR TITLE
Require PHP 8.1+ and modernize codebase

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+                php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
         steps:
             -
                 name: Checkout code

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,11 +8,10 @@ on:
     workflow_dispatch:
 jobs:
     checks:
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
                 php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
         steps:
             -
@@ -30,3 +29,26 @@ jobs:
             -
                 name: Run checks
                 run: composer check
+
+    tests-windows:
+        runs-on: windows-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        steps:
+            -
+                name: Checkout code
+                uses: actions/checkout@v6
+            -
+                name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-version }}
+            -
+                name: Install dependencies
+                run: composer install --no-progress --prefer-dist --no-interaction
+
+            -
+                name: Run tests
+                run: composer check:tests

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,23 @@
         "static analysis"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "phpstan/phpstan": "^2.1.8"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "^2.45.0",
+        "editorconfig-checker/editorconfig-checker": "^10.7.0",
+        "ergebnis/composer-normalize": "^2.52.0",
         "phpstan/phpstan-deprecation-rules": "^2.0.1",
         "phpstan/phpstan-phpunit": "^2.0.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",
-        "phpunit/phpunit": "^9.6.22",
+        "phpunit/phpunit": "^10.5.63",
         "shipmonk/coding-standard": "^0.2.0",
         "shipmonk/composer-dependency-analyser": "^1.8.1",
-        "shipmonk/dead-code-detector": "^0.9.0",
+        "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "^2.1.1"
     },
     "suggest": {
-        "phpunit/phpunit": "^9.6.22 for running tests that use RuleTestCase"
+        "phpunit/phpunit": "^10.5.63 for running tests that use RuleTestCase"
     },
     "autoload": {
         "psr-4": {
@@ -51,6 +52,7 @@
     "scripts": {
         "check": [
             "@check:composer",
+            "@check:ec",
             "@check:cs",
             "@check:types",
             "@check:tests",
@@ -64,7 +66,8 @@
         ],
         "check:cs": "phpcs",
         "check:dependencies": "composer-dependency-analyser",
-        "check:tests": "phpunit -vvv tests",
+        "check:ec": "ec src tests",
+        "check:tests": "phpunit tests",
         "check:types": "phpstan analyse -vv --ansi",
         "fix:cs": "phpcbf"
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,16 +8,8 @@
 
     <file>src/</file>
 
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80100"/>
     <config name="installed_paths" value="vendor/slevomat/coding-standard,vendor/shipmonk/coding-standard"/>
 
-    <rule ref="ShipMonkCodingStandard">
-        <exclude name="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden"/><!-- It removes @dataProvider, but PHPUnit 9 does not yet have #[DataProvider] -->
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
-        <properties>
-            <property name="onlySingleLine" value="false"/>
-        </properties>
-    </rule>
+    <rule ref="ShipMonkCodingStandard"/>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,8 +9,8 @@ includes:
 
 parameters:
     phpVersion:
-        min: 70400
-        max: 80499
+        min: 80100
+        max: 80599
     internalErrorsCountLimit: 1
     paths:
         - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        colors="true"
-        bootstrap="vendor/autoload.php"
-        beStrictAboutOutputDuringTests="true"
-        beStrictAboutChangesToGlobalState="true"
-        beStrictAboutCoversAnnotation="true"
-        beStrictAboutTodoAnnotatedTests="true"
-        failOnRisky="true"
-        failOnWarning="true"
-        cacheResultFile="cache/phpunit.result.cache"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    cacheDirectory="cache/phpunit"
+    colors="true"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnPhpunitDeprecations="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="depends,defects"
+    failOnDeprecation="true"
+    failOnIncomplete="true"
+    failOnNotice="true"
+    failOnPhpunitDeprecation="true"
+    failOnRisky="true"
+    failOnWarning="true"
 >
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
     <php>
         <ini name="error_reporting" value="-1"/>
     </php>

--- a/src/RuleTestCase.php
+++ b/src/RuleTestCase.php
@@ -22,7 +22,7 @@ use function preg_replace;
 use function sort;
 use function sprintf;
 use function str_replace;
-use function strpos;
+use function str_starts_with;
 use function trim;
 use function uniqid;
 use const DIRECTORY_SEPARATOR;
@@ -39,7 +39,7 @@ abstract class RuleTestCase extends OriginalRuleTestCase
      */
     protected function analyzeFiles(
         array $files,
-        bool $autofix = false
+        bool $autofix = false,
     ): void
     {
         sort($files);
@@ -49,7 +49,7 @@ abstract class RuleTestCase extends OriginalRuleTestCase
 
         if ($autofix) {
             foreach ($files as $file) {
-                $fileErrors = array_filter($analyserErrors, static fn (Error $error): bool => strpos($error->getFile(), $file) === 0);
+                $fileErrors = array_filter($analyserErrors, static fn (Error $error): bool => str_starts_with($error->getFile(), $file));
                 $this->autofix($file, array_values($fileErrors));
             }
 
@@ -60,7 +60,7 @@ abstract class RuleTestCase extends OriginalRuleTestCase
         }
 
         foreach ($files as $file) {
-            $fileErrors = array_filter($analyserErrors, static fn (Error $error): bool => strpos($error->getFile(), $file) === 0);
+            $fileErrors = array_filter($analyserErrors, static fn (Error $error): bool => str_starts_with($error->getFile(), $file));
             $actualErrors = $this->processActualErrors(array_values($fileErrors));
             $expectedErrors = $this->parseExpectedErrors($file);
 
@@ -126,7 +126,7 @@ abstract class RuleTestCase extends OriginalRuleTestCase
 
     private function formatErrorForAssert(
         string $message,
-        int $line
+        int $line,
     ): string
     {
         return sprintf('%02d: %s', $line, $message);
@@ -137,7 +137,7 @@ abstract class RuleTestCase extends OriginalRuleTestCase
      */
     private function autofix(
         string $file,
-        array $analyserErrors
+        array $analyserErrors,
     ): void
     {
         $errorsByLines = [];


### PR DESCRIPTION
Drops PHP 7.4/8.0 support and aligns the project with the recent upgrades of sibling shipmonk OS libs (`dead-code-detector`, `input-mapper`, `composer-dependency-analyser`).

## Changes

- **composer**: require `php: ^8.1`, bump `phpunit/phpunit` to `^10.5`, `shipmonk/dead-code-detector` to `^1.0`; add `editorconfig-checker/editorconfig-checker` with a `check:ec` step wired into `composer check`. Dropped the now-invalid `-vvv` flag from `check:tests` (removed in PHPUnit 10).
- **phpunit.xml.dist**: migrated to the PHPUnit 10 schema — removed dropped options (`beStrictAboutCoversAnnotation`, `beStrictAboutTodoAnnotatedTests`, `cacheResultFile`), switched to `cacheDirectory`, added `<testsuites>`/`<source>` and the modern `failOn*`/`displayDetailsOn*` strictness flags.
- **phpcs**: `php_version` → `80100`; removed the two PHP-7.4-era workarounds (the `@dataProvider`/`AnnotationForbidden` exclusion and the `DisallowTrailingCommaInDeclaration onlySingleLine=false` override) so the standard's defaults apply.
- **phpstan**: `phpVersion` range → `80100`–`80599`.
- **RuleTestCase**: use `str_starts_with()` instead of `strpos(...) === 0`; add the trailing commas now required in multi-line declarations.
- **CI**: dropped `7.4`/`8.0`. Full `composer check` runs across the Linux × PHP 8.1–8.5 matrix; a separate Windows job runs the test suite (Windows keeps coverage of the `DIRECTORY_SEPARATOR` path logic but cannot run `editorconfig-checker`, whose release ships no installable Windows binary — same reason sibling libs only lint on Linux).

`composer check` passes locally (also enforced by the pre-commit hook).

Co-Authored-By: Claude Code